### PR TITLE
Add a SimulationRegistry interface to record sim session starts/stops.

### DIFF
--- a/src/main/java/com/tarterware/roadrunner/models/SimulationSession.java
+++ b/src/main/java/com/tarterware/roadrunner/models/SimulationSession.java
@@ -1,0 +1,42 @@
+package com.tarterware.roadrunner.models;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents a discrete simulation execution window within the Roadrunner
+ * system. *
+ * <p>
+ * This model is used by the
+ * {@link com.tarterware.roadrunner.ports.SimulationRegistry} to track the
+ * lifecycle of vehicle simulations. It provides the temporal boundaries (start
+ * and end times) necessary for the playback engine to seek specific offsets
+ * within Kafka topics.
+ * </p>
+ * * @see com.tarterware.roadrunner.ports.SimulationRegistry
+ */
+@NoArgsConstructor
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SimulationSession
+{
+    /**
+     * The unique identifier for the vehicle in this simulation session.
+     */
+    UUID id;
+
+    /**
+     * The precise timestamp when the simulation began.
+     */
+    Instant start;
+
+    /**
+     * The precise timestamp when the simulation concluded.
+     */
+    Instant end;
+}

--- a/src/main/java/com/tarterware/roadrunner/ports/SimulationRegistry.java
+++ b/src/main/java/com/tarterware/roadrunner/ports/SimulationRegistry.java
@@ -1,0 +1,49 @@
+package com.tarterware.roadrunner.ports;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Port interface for managing the persistence and retrieval of simulation session metadata.
+ *
+ * <p>
+ * This registry acts as a specialized state store that tracks the temporal boundaries 
+ * of simulation runs. It enables the system to "interrogate" past events, providing 
+ * the necessary start and end timestamps required for the playback engine to 
+ * perform time-based seeks within Kafka topics.
+ * </p>
+ *
+ * @see com.tarterware.roadrunner.models.SimulationSession
+ * @see com.tarterware.roadrunner.adapters.kafka.KafkaVehicleEventPublisher
+ */
+import com.tarterware.roadrunner.models.SimulationSession;
+
+public interface SimulationRegistry
+{
+    /**
+     * Records the start of a simulation session.
+     *
+     * @param vehicleID the unique identifier for the vehicle in the simulation
+     *                  session
+     * @param startTime the precise timestamp when the simulation began
+     */
+    void recordStart(UUID vehicleID, Instant startTime);
+
+    /**
+     * Records the conclusion of a simulation session by updating its end timestamp.
+     *
+     * @param vehicleID the unique identifier for the vehicle in the simulation
+     *                  session
+     * @param endTime   the precise timestamp when the simulation concluded
+     */
+    void recordEnd(UUID vehicleID, Instant startTime);
+
+    /**
+     * Retrieves a complete history of all recorded simulation sessions.
+     *
+     * @return a list of {@link SimulationSession} objects representing both
+     *         historical and active simulations.
+     */
+    List<SimulationSession> getAllSessions();
+}

--- a/src/test/java/com/tarterware/roadrunner/models/SimulationSessionSerializationTest.java
+++ b/src/test/java/com/tarterware/roadrunner/models/SimulationSessionSerializationTest.java
@@ -1,0 +1,66 @@
+package com.tarterware.roadrunner.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class SimulationSessionSerializationTest
+{
+    @Test
+    void testJsonSerialization() throws JsonMappingException, JsonProcessingException
+    {
+        // 1. Setup ObjectMapper to handle Java 8 Dates/Times correctly
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+
+        // Create the original session with nanosecond precision
+        UUID vehicleId = UUID.randomUUID();
+        Instant endTime = Instant.now();
+        Instant startTime = endTime.minusMillis(100000);
+
+        // Simulate an ongoing session by leaving end null
+        SimulationSession originalSession = new SimulationSession();
+        originalSession.setId(vehicleId);
+        originalSession.setStart(startTime);
+        originalSession.setEnd(null);
+
+        // Serialize to JSON string
+        String json = mapper.writeValueAsString(originalSession);
+        System.out.println("Serialized JSON: " + json);
+
+        // Deserialize back to an object
+        SimulationSession deserializedSession = mapper.readValue(json, SimulationSession.class);
+
+        // Assertions to verify no loss of precision
+        assertEquals(originalSession.getId(), deserializedSession.getId(), "IDs must match");
+        assertEquals(originalSession.getStart(), deserializedSession.getStart(), "Start time nanoseconds must match");
+        assertEquals(originalSession.getEnd(), deserializedSession.getEnd(), "End time nanoseconds must match");
+
+        // Repeat test with end time set
+        originalSession.setEnd(endTime);
+
+        // Serialize to JSON string
+        json = mapper.writeValueAsString(originalSession);
+        System.out.println("Serialized JSON: " + json);
+
+        // Deserialize back to an object
+        deserializedSession = mapper.readValue(json, SimulationSession.class);
+
+        // Assertions to verify no loss of precision
+        assertEquals(originalSession.getId(), deserializedSession.getId(), "IDs must match");
+        assertEquals(originalSession.getStart(), deserializedSession.getStart(), "Start time nanoseconds must match");
+        assertEquals(originalSession.getEnd(), deserializedSession.getEnd(), "End time nanoseconds must match");
+
+        // Explicitly check nanosecond equality
+        assertEquals(originalSession.getStart().getNano(), deserializedSession.getStart().getNano(),
+                "Nanosecond precision lost");
+    }
+}


### PR DESCRIPTION
Add model to represent a Simulation Session, to be returned by the registry on inquiries.