### PR TITLE
Add new /api/vehicle/simulation-sessions endpoint and add unit tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
             <version>1.20.6</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/com/tarterware/roadrunner/adapters/kafka/KafkaVehicleEventConsumer.java
+++ b/src/main/java/com/tarterware/roadrunner/adapters/kafka/KafkaVehicleEventConsumer.java
@@ -5,7 +5,9 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.event.EventListener;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.event.ListenerContainerIdleEvent;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
@@ -93,7 +95,7 @@ public class KafkaVehicleEventConsumer
         {
 
             case "CREATED":
-                log.debug("CREATED");
+                log.debug("CREATED: {}", event.vehicleId());
 
                 // Create a new vehicleState and populate with the event
                 vehicleState = new VehicleState();
@@ -116,12 +118,13 @@ public class KafkaVehicleEventConsumer
                 break;
 
             case "MOVING":
-                log.debug("MOVING");
+                log.debug("MOVING: {}", event.vehicleId());
                 vehicleId = UUID.fromString(event.vehicleId());
                 vehicleState = vehicleStateStore.getVehicle(vehicleId);
                 if (vehicleState == null)
                 {
-                    throw new RuntimeException("No vehicle with ID " + vehicleId);
+                    // throw new RuntimeException("No vehicle with ID " + vehicleId);
+                    vehicleState = new VehicleState();
                 }
 
                 // Ensure this isn't a stale event. The new sequence number should be greater.
@@ -146,7 +149,7 @@ public class KafkaVehicleEventConsumer
                 break;
 
             case "DELETED":
-                log.debug("DELETED");
+                log.debug("DELETED: {}", event.vehicleId());
 
                 vehicleId = UUID.fromString(event.vehicleId());
                 vehicleStateStore.deleteVehicle(vehicleId);
@@ -158,4 +161,9 @@ public class KafkaVehicleEventConsumer
         }
     }
 
+    @EventListener
+    public void handleListenerContainerIdle(ListenerContainerIdleEvent event)
+    {
+        log.info("Consumer is idle and ready on partitions: {}", event.getTopicPartitions());
+    }
 }

--- a/src/main/java/com/tarterware/roadrunner/components/VehicleManager.java
+++ b/src/main/java/com/tarterware/roadrunner/components/VehicleManager.java
@@ -578,18 +578,20 @@ public class VehicleManager
                                 statisticsCollector.recordMeasurement(msJitter);
 
                                 // Update vehicle execution time and store vehicle state
-                                vehicle.setLastNsExecutionTime(System.nanoTime() - nsVehicleStartTime);
-                                vehicle.setLastCalculationEpochMillis(Instant.now().toEpochMilli());
-
-                                // Mark that this manager calculated the vehicle state.
-                                vehicle.setManagerHost(hostName);
-
-                                this.vehicleStateStore.saveVehicle(vehicle.getVehicleState());
-                                this.vehicleEventPublisher.publishVehicleUpdated(vehicle);
-
-                                // If the vehicle was not updated, see if it has reached timeout.
-                                if (!updated)
+                                if (updated)
                                 {
+                                    vehicle.setLastNsExecutionTime(System.nanoTime() - nsVehicleStartTime);
+                                    vehicle.setLastCalculationEpochMillis(Instant.now().toEpochMilli());
+
+                                    // Mark that this manager calculated the vehicle state.
+                                    vehicle.setManagerHost(hostName);
+
+                                    this.vehicleStateStore.saveVehicle(vehicle.getVehicleState());
+                                    this.vehicleEventPublisher.publishVehicleUpdated(vehicle);
+                                }
+                                else
+                                {
+                                    // If the vehicle was not updated, see if it has reached timeout.
                                     if (vehicle.getLastCalculationEpochMillis() < msEpochTimeoutTime)
                                     {
                                         deletionSet.add(vehicleId);

--- a/src/main/java/com/tarterware/roadrunner/controllers/VehicleController.java
+++ b/src/main/java/com/tarterware/roadrunner/controllers/VehicleController.java
@@ -28,10 +28,12 @@ import com.tarterware.roadrunner.components.Vehicle;
 import com.tarterware.roadrunner.components.VehicleManager;
 import com.tarterware.roadrunner.models.Address;
 import com.tarterware.roadrunner.models.CrissCrossPlan;
+import com.tarterware.roadrunner.models.SimulationSession;
 import com.tarterware.roadrunner.models.TripPlan;
 import com.tarterware.roadrunner.models.VehicleState;
 import com.tarterware.roadrunner.models.mapbox.Directions;
 import com.tarterware.roadrunner.ports.ControllerVehicleStateStore;
+import com.tarterware.roadrunner.ports.SimulationRegistry;
 import com.tarterware.roadrunner.utilities.TopologyUtilities;
 
 /**
@@ -54,9 +56,12 @@ import com.tarterware.roadrunner.utilities.TopologyUtilities;
 @RequestMapping("/api/vehicle")
 public class VehicleController
 {
+
     private VehicleManager vehicleManager;
 
     private ControllerVehicleStateStore vehicleStateStore;
+
+    private SimulationRegistry simulationRegistry;
 
     private static final Logger log = LoggerFactory.getLogger(VehicleController.class);
 
@@ -69,12 +74,16 @@ public class VehicleController
      * @param vehicleStateStore the port providing access to the current persisted
      *                          vehicle states
      */
-    VehicleController(VehicleManager vehicleManager, ControllerVehicleStateStore vehicleStateStore)
+    VehicleController(
+            VehicleManager vehicleManager,
+            ControllerVehicleStateStore vehicleStateStore,
+            SimulationRegistry simulationRegistry)
     {
         this.vehicleManager = vehicleManager;
         this.vehicleStateStore = vehicleStateStore;
-        log.info("vehicleStateStore is {}", vehicleStateStore);
+        this.simulationRegistry = simulationRegistry;
 
+        log.info("vehicleStateStore is {}", vehicleStateStore);
     }
 
     /**
@@ -84,8 +93,9 @@ public class VehicleController
      * @return a {@link ResponseEntity} containing the initial {@link VehicleState}
      */
     @PostMapping("/create-new")
-    ResponseEntity<VehicleState> getNewVehicle(@RequestBody
-    TripPlan tripPlan)
+    ResponseEntity<VehicleState> getNewVehicle(
+            @RequestBody
+            TripPlan tripPlan)
     {
         Vehicle vehicle = vehicleManager.createVehicle(tripPlan);
         VehicleState vehicleState = vehicle.getVehicleState();
@@ -109,8 +119,9 @@ public class VehicleController
      * @return a list of {@link VehicleState} objects for the created vehicles
      */
     @PostMapping("/create-crisscross")
-    ResponseEntity<List<VehicleState>> createCrissCrossVehicles(@RequestBody
-    CrissCrossPlan crissCrossPlan)
+    ResponseEntity<List<VehicleState>> createCrissCrossVehicles(
+            @RequestBody
+            CrissCrossPlan crissCrossPlan)
     {
         List<VehicleState> listVehicleStates = new ArrayList<VehicleState>();
 
@@ -168,8 +179,9 @@ public class VehicleController
      *         {@code HttpStatus.NOT_FOUND}
      */
     @GetMapping("/get-vehicle-state/{vehicleId}")
-    ResponseEntity<VehicleState> getVehicleStateFor(@PathVariable
-    String vehicleId)
+    ResponseEntity<VehicleState> getVehicleStateFor(
+            @PathVariable
+            String vehicleId)
     {
         VehicleState vehicleState = vehicleStateStore.getVehicle(UUID.fromString(vehicleId));
         if (vehicleState == null)
@@ -189,8 +201,9 @@ public class VehicleController
      *         {@code HttpStatus.NOT_FOUND}
      */
     @GetMapping("/get-vehicle-directions/{vehicleId}")
-    ResponseEntity<Directions> getVehicleDirectionsFor(@PathVariable
-    String vehicleId)
+    ResponseEntity<Directions> getVehicleDirectionsFor(
+            @PathVariable
+            String vehicleId)
     {
         Directions directions = vehicleManager.getVehicleDirections(UUID.fromString(vehicleId), true);
         if (directions == null)
@@ -209,8 +222,9 @@ public class VehicleController
      * @return a {@link PagedModel} containing the requested slice of vehicle states
      */
     @GetMapping("/get-all-vehicle-states")
-    ResponseEntity<PagedModel<VehicleState>> getAllVehicleStates(@RequestParam(defaultValue = "0")
-    int page,
+    ResponseEntity<PagedModel<VehicleState>> getAllVehicleStates(
+            @RequestParam(defaultValue = "0")
+            int page,
             @RequestParam(defaultValue = "10")
             int pageSize)
     {
@@ -228,6 +242,49 @@ public class VehicleController
                 vehicleStatePage.getSize(), vehicleStatePage.getNumber(), vehicleStatePage.getTotalElements()));
 
         return new ResponseEntity<>(pagedModel, HttpStatus.OK);
+    }
+
+    @GetMapping("/simulation-sessions")
+    ResponseEntity<PagedModel<SimulationSession>> getSimulationSessions(
+            @RequestParam(defaultValue = "0")
+            int page,
+            @RequestParam(defaultValue = "10")
+            int pageSize)
+    {
+        List<SimulationSession> allSessions = simulationRegistry.getAllSessions();
+
+        List<SimulationSession> pageList = new ArrayList<SimulationSession>();
+        int size = allSessions.size();
+
+        if (size > 0)
+        {
+            int start = page * pageSize;
+            if (start > size)
+            {
+                throw new IllegalArgumentException(
+                        "Page " + page + " of page size " + pageSize + " outside " + size + " bounds!");
+            }
+            int end = start + pageSize;
+            if (end > size)
+            {
+                end = size;
+            }
+            pageList = allSessions.subList(start, end);
+        }
+
+        // Create a Page object
+        Page<SimulationSession> simSessionsPage = new PageImpl<>(
+                pageList,
+                PageRequest.of(page, pageSize),
+                size);
+
+        // Create a PagedModel object
+        PagedModel<SimulationSession> pagedModel = PagedModel.of(simSessionsPage.getContent(),
+                new PagedModel.PageMetadata(
+                        simSessionsPage.getSize(), simSessionsPage.getNumber(), simSessionsPage.getTotalElements()));
+
+        return new ResponseEntity<>(pagedModel, HttpStatus.OK);
+
     }
 
     /**
@@ -253,7 +310,9 @@ public class VehicleController
      * @return a map of vehicle UUIDs to their current {@link VehicleState}
      * @throws IllegalArgumentException if the requested page is out of bounds
      */
-    public Map<UUID, VehicleState> getVehicleMap(int page, int pageSize)
+    public Map<UUID, VehicleState> getVehicleMap(
+            int page,
+            int pageSize)
     {
         // Create a Map of Vehicles to return
         Map<UUID, VehicleState> vMap = new HashMap<>();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,10 +26,12 @@ prometheus.secret.name=prometheus-token-secret
 # Uncomment to display updateVehicle execution statistics in log.
 # logging.level.com.tarterware.roadrunner.components.VehicleManager=DEBUG
 
+# logging.level.com.tarterware.roadrunner.adapters.kafka.KafkaVehicleEventConsumer=DEBUG
 # logging.level.com.tarterware.roadrunner.adapters.kafka.KafkaVehicleEventPublisher=DEBUG
 
 # Kafka configuration
 spring.kafka.bootstrap-servers=localhost:9094
+spring.kafka.listener.concurrency=3
 spring.kafka.producer.acks=all
 spring.kafka.producer.properties.enable.idempotence=true
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
@@ -37,9 +39,14 @@ spring.kafka.producer.value-serializer=org.springframework.kafka.support.seriali
 
 spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
 spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+spring.kafka.consumer.auto-offset-reset=earliest
 spring.kafka.consumer.properties.spring.deserializer.value.delegate.class=org.springframework.kafka.support.serializer.JsonDeserializer
 spring.kafka.consumer.properties.spring.json.trusted.packages=com.tarterware.roadrunner.messaging
 spring.kafka.consumer.properties.spring.json.use.type.headers=true
 spring.kafka.consumer.properties.spring.json.value.default.type=com.tarterware.roadrunner.messaging.VehiclePositionEvent
 
-com.tarterware.roadrunner.kafka.topic.vehicle-position=vehicle.position.v1
+# Reduce the time the broker waits for a consumer to respond
+spring.kafka.consumer.properties.heartbeat.interval.ms=3000
+spring.kafka.consumer.properties.session.timeout.ms=10000
+
+com.tarterware.roadrunner.kafka.topic.vehicle-position=vehicle.position.v2

--- a/src/test/java/com/tarterware/roadrunner/controllers/SimulationSessionControllerIntegrationTest.java
+++ b/src/test/java/com/tarterware/roadrunner/controllers/SimulationSessionControllerIntegrationTest.java
@@ -14,7 +14,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -29,7 +32,16 @@ import com.tarterware.roadrunner.adapters.redis.RedisDirectionsCache;
 import com.tarterware.roadrunner.adapters.redis.RedisFeatureCollectionCache;
 import com.tarterware.roadrunner.adapters.redis.RedisIsochroneCache;
 import com.tarterware.roadrunner.adapters.redis.RedisTripPlanRepository;
+import com.tarterware.roadrunner.configs.RedisConfig;
+import com.tarterware.roadrunner.configs.SecurityConfig;
 import com.tarterware.roadrunner.ports.SimulationRegistry;
+import com.tarterware.roadrunner.ports.SimulationVehicleStateStore;
+import com.tarterware.roadrunner.ports.VehicleEventPublisher;
+import com.tarterware.roadrunner.services.DirectionsService;
+import com.tarterware.roadrunner.services.GeocodingService;
+import com.tarterware.roadrunner.services.IsochroneService;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
 
 @SpringBootTest
 @Testcontainers
@@ -69,6 +81,39 @@ public class SimulationSessionControllerIntegrationTest
 
     @MockitoBean
     private RedisTripPlanRepository redisTripPlanRepository;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @MockitoBean
+    private DirectionsService directionsService;
+
+    @MockitoBean
+    private GeocodingService geocodingService;
+
+    @MockitoBean
+    private IsochroneService isochroneService;
+
+    @MockitoBean
+    private SecurityConfig securityConfig;
+
+    @MockitoBean
+    private RedisConfig redisConfig;
+
+    @MockitoBean
+    private SecurityFilterChain filterChain;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @MockitoBean
+    private SimulationVehicleStateStore vehicleStateStore;
+
+    @MockitoBean
+    private VehicleEventPublisher vehicleEventPublisher;
+
+    @MockitoBean
+    private KubernetesClient kubernetesClient;
 
     @BeforeEach
     void setUp()

--- a/src/test/java/com/tarterware/roadrunner/controllers/SimulationSessionControllerIntegrationTest.java
+++ b/src/test/java/com/tarterware/roadrunner/controllers/SimulationSessionControllerIntegrationTest.java
@@ -1,0 +1,111 @@
+package com.tarterware.roadrunner.controllers;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import com.tarterware.roadrunner.adapters.redis.RedisDirectionsCache;
+import com.tarterware.roadrunner.adapters.redis.RedisFeatureCollectionCache;
+import com.tarterware.roadrunner.adapters.redis.RedisIsochroneCache;
+import com.tarterware.roadrunner.adapters.redis.RedisTripPlanRepository;
+import com.tarterware.roadrunner.ports.SimulationRegistry;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class SimulationSessionControllerIntegrationTest
+{
+
+    @Container
+    public static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:7.2-alpine"))
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry)
+    {
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", redis::getFirstMappedPort);
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private SimulationRegistry simulationRegistry;
+
+    // @Autowired
+    // private RedisTemplate<String, Object> redisTemplate;
+
+    @MockitoBean
+    private RedisDirectionsCache redisDirectionsCache;
+
+    @MockitoBean
+    private RedisFeatureCollectionCache redisFeatureCollectionCache;
+
+    @MockitoBean
+    private RedisIsochroneCache redisIsochroneCache;
+
+    @MockitoBean
+    private RedisTripPlanRepository redisTripPlanRepository;
+
+    @BeforeEach
+    void setUp()
+    {
+        // Clean the specific key before each test
+        // redisTemplate.delete("roadrunner:simulations");
+    }
+
+    @Test
+    void shouldReturnChronologicalSimulationSessions() throws Exception
+    {
+        // Arrange: Record two sessions in the registry
+        UUID simId1 = UUID.randomUUID();
+        UUID simId2 = UUID.randomUUID();
+        Instant now = Instant.now();
+
+        // Sim 1 started 10 minutes ago and finished 5 minutes ago
+        simulationRegistry.recordStart(simId1, now.minusSeconds(600));
+        simulationRegistry.recordEnd(simId1, now.minusSeconds(300));
+
+        // Sim 2 started 2 minutes ago and is still active (end is null)
+        simulationRegistry.recordStart(simId2, now.minusSeconds(120));
+
+        // Act & Assert
+        mockMvc.perform(get("/api/vehicle/simulation-sessions")
+                .with(jwt())
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                // Verify the length of the nested list
+                .andExpect(jsonPath("$._embedded.simulationSessions.length()").value(2))
+
+                // Verify the first session (ID and End time exists)
+                .andExpect(jsonPath("$._embedded.simulationSessions[0].id").value(simId1.toString()))
+                .andExpect(jsonPath("$._embedded.simulationSessions[0].end").exists())
+
+                // Verify the second session (ID and End time is null)
+                .andExpect(jsonPath("$._embedded.simulationSessions[1].id").value(simId2.toString()))
+                .andExpect(jsonPath("$._embedded.simulationSessions[1].end").value(nullValue()));
+    }
+}


### PR DESCRIPTION
Rather than throw, just create vehicle if MOVING comes in before CREATED. Ensure VehicleState is saved in stroe before CREATE or MOVING event is published.